### PR TITLE
:bookmark: release 1.0.3

### DIFF
--- a/.github/workflows/release-tauri.yaml
+++ b/.github/workflows/release-tauri.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable
       - name: install dependencies (ubuntu only)
@@ -89,6 +89,7 @@ jobs:
                   core.exportVariable("APPLE_SIGNING_IDENTITY", `${{ secrets.APPLE_SIGNING_IDENTITY }}`);
                   core.exportVariable("APPLE_ID", `${{ secrets.APPLE_ID }}`);
                   core.exportVariable("APPLE_PASSWORD", `${{ secrets.APPLE_PASSWORD }}`);
+                  core.exportVariable("APPLE_TEAM_ID", `${{ secrets.APPLE_TEAM_ID }}`);
                   core.notice("符合签名条件", {title:"本次构建将会对MacOS目标进行签名"});
                 } else {
                   core.warning("未提供有效证书", {title:"本次构建将不会对MacOS目标进行签名"});
@@ -106,7 +107,7 @@ jobs:
             }
             require('fs').writeFileSync('./src-tauri/tauri.conf.json', JSON.stringify(cfg));
       - name: install frontend dependencies
-        run: npm ci
+        run: npm install
       - uses: tauri-apps/tauri-action@v0
         id: tauri-action-build
         env:
@@ -169,4 +170,23 @@ jobs:
               release_id: process.env.release_id,
               draft: false,
               prerelease: false
+            })
+  
+  remove-release-if-not-success:
+    needs: [create-release, publish-release]
+    if: "always() && needs.publish-release.result != 'success'"
+    permissions:
+      contents: write
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: remove release
+        uses: actions/github-script@v6
+        env:
+          release_id: ${{ needs.create-release.outputs.release_id }}
+        with:
+          script: |
+            await github.rest.repos.deleteRelease({
+              release_id: process.env.release_id,
+              owner: context.repo.owner, repo: context.repo.repo,
             })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ceobe-canteen-electron",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "description": "帮小刻找好多好吃的饼",
   "author": "CeobeCanteen",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceobe-canteen-desktop"
-version = "1.0.2"
+version = "1.0.3"
 description = "小刻食堂的桌面端，恭喜你电脑有多了个和小刻一样喜欢吃东西的浏览器内核 "
 authors = ["FrozenString<frozenstringstable@gmail.com>"]
 license="AGPL-3"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -48,15 +48,14 @@ serde_repr = "0.1.16"
 [target.'cfg(windows)'.dependencies.windows]
 version = "0.39"
 features = [
-    "UI_Notifications",
-    "Data_Xml_Dom",
-    "Foundation",
     "Win32_Foundation",
     "Win32_Security",
     "Win32_System_Com",
     "Win32_System_Threading",
     "Win32_UI_WindowsAndMessaging",
 ]
+[target.'cfg(windows)'.dependencies. winrt-toast]
+version = "0.1.1"
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem and the built-in dev server is disabled.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -47,7 +47,10 @@ reqwest-retry = "0.2"
 serde_repr = "0.1.16"
 [target.'cfg(windows)'.dependencies.windows]
 version = "0.39"
-features = ["Data_Xml_Dom",
+features = [
+    "UI_Notifications",
+    "Data_Xml_Dom",
+    "Foundation",
     "Win32_Foundation",
     "Win32_Security",
     "Win32_System_Com",

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -10,8 +10,8 @@ mod quit;
 mod request_client;
 mod request_refer_image;
 mod resource_location;
-mod update_available;
 mod system_notification;
+mod update_available;
 
 pub use self::auto_launch::{auto_launch_setting, set_auto_launch};
 pub use clipboard::copy_image;

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -12,6 +12,7 @@ mod request_refer_image;
 mod resource_location;
 mod system_notification;
 mod update_available;
+mod should_silence;
 
 pub use self::auto_launch::{auto_launch_setting, set_auto_launch};
 pub use clipboard::copy_image;
@@ -26,3 +27,4 @@ pub use request_client::send_request;
 pub use request_refer_image::request_refer_image;
 pub use resource_location::{get_app_cache_path, get_app_config_path};
 pub use system_notification::send_system_notification;
+pub use should_silence::should_silence;

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -11,6 +11,7 @@ mod request_client;
 mod request_refer_image;
 mod resource_location;
 mod update_available;
+mod system_notification;
 
 pub use self::auto_launch::{auto_launch_setting, set_auto_launch};
 pub use clipboard::copy_image;

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -25,3 +25,4 @@ pub use quit::quit;
 pub use request_client::send_request;
 pub use request_refer_image::request_refer_image;
 pub use resource_location::{get_app_cache_path, get_app_config_path};
+pub use system_notification::send_system_notification;

--- a/src-tauri/src/commands/should_silence.rs
+++ b/src-tauri/src/commands/should_silence.rs
@@ -1,0 +1,39 @@
+use tauri::command;
+
+#[command]
+pub fn should_silence() -> tauri::Result<bool> {
+    #[cfg(windows)]
+    {
+        use std::mem::size_of;
+        use windows::Win32::{
+            Foundation::{RECT},
+            Graphics::Gdi::{GetMonitorInfoW, MonitorFromWindow, MONITORINFO, MONITOR_DEFAULTTOPRIMARY},
+            UI::WindowsAndMessaging::{
+                GetDesktopWindow, GetForegroundWindow, GetShellWindow, GetWindowRect,
+            },
+        };
+
+        let shell = unsafe { GetShellWindow() };
+        let desktop = unsafe { GetDesktopWindow() };
+        let hwnd = unsafe { GetForegroundWindow() };
+        if hwnd.0 == 0 ||( hwnd == shell || hwnd == desktop ){
+            Ok(false)
+        } else {
+            let mut rect = RECT::default();
+            unsafe { GetWindowRect(hwnd, &mut rect) };
+
+            let mut monitor_info = MONITORINFO {
+                cbSize: size_of::<MONITORINFO>() as u32,
+                ..Default::default()
+            };
+            let monitor = unsafe { MonitorFromWindow(hwnd, MONITOR_DEFAULTTOPRIMARY) };
+            unsafe { GetMonitorInfoW(monitor, &mut monitor_info) };
+
+            let monitor_size = monitor_info.rcMonitor;
+
+            Ok(rect.left == monitor_size.left && rect.right == monitor_size.right && rect.top == monitor_size.top && rect.bottom == monitor_size.bottom)
+        }
+    }
+    #[cfg(not(windows))]
+    Ok(false)
+}

--- a/src-tauri/src/commands/system_notification.rs
+++ b/src-tauri/src/commands/system_notification.rs
@@ -1,0 +1,55 @@
+use serde::{Deserialize, Serialize};
+use tauri::api::notification::Sound;
+use tauri::AppHandle;
+use windows::core::InParam;
+use windows::Data::Xml::Dom::{IXmlNode, XmlDocument};
+use windows::UI::Notifications::{Notification, ToastNotificationManager, ToastTemplateType};
+use crate::commands::request_refer_image;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NotificationPayload {
+    title: String,
+    icon: Option<String>,
+    body: String,
+    has_sound: bool,
+    image_url: Option<String>,
+}
+
+#[cfg(windows)]
+pub async fn send_system_notification(app: AppHandle, payload: NotificationPayload) -> tauri::Result<()> {
+    #[cfg(windows)]
+    {
+        let xml = ToastNotificationManager::GetTemplateContent(ToastTemplateType::ToastImageAndText02).expect("get template failure");
+        let header_node = xml.GetElementsByTagName(&("header".into())).unwrap();
+        let header_node = header_node.Item(0).unwrap();
+        let attr = header_node.Attributes().unwrap();
+        let attr_title = attr.GetNamedItem(&("title".into())).unwrap();
+        attr_title.SetInnerText(&(payload.title.into())).unwrap();
+
+        let text_node = xml.GetElementsByTagName(&("text".into())).expect("get template failure");
+        let first_line = text_node.GetAt(0).unwrap();
+        first_line.AppendChild::<InParam<IXmlNode>,_>(InParam::owned(xml.CreateTextNode(&(payload.body.into())).unwrap().into())).expect("TODO: panic message");
+
+        if let Some(img_url) = payload.image_url {
+            let base64 = request_refer_image(&img_url, "", app).await.unwrap();
+            let image_node = xml.GetElementsByTagName(&("image".into())).unwrap();
+            let image_node = image_node.Item(0).unwrap();
+            let img_attr = image_node.Attributes().unwrap();
+            let img_src = img_attr.GetNamedItem(&("src".into())).unwrap();
+            img_src.SetInnerText(&(base64.into())).unwrap();
+        }
+    }
+    #[cfg(not(windows))]
+    {
+        let mut notify = tauri::api::notification::Notification::new(&app.config().tauri.bundle.identifier).title(payload.title).body(payload.body);
+        if let Some(icon) = payload.icon {
+            notify = notify.icon(icon);
+        }
+        if payload.has_sound {
+            notify = notify.sound(Sound::Default)
+        }
+        notify.show()?;
+    }
+
+    Ok(())
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -15,7 +15,8 @@ use tauri::{generate_context, Builder, Context, Manager, WindowEvent};
 use crate::commands::{
     auto_launch_setting, back_preview, copy_image, front_logger, get_app_cache_path,
     get_app_config_path, get_item, get_monitor_info, hide_notification, is_debug, message_beep,
-    quit, read_detail, request_refer_image, send_request, set_auto_launch, set_item,send_system_notification
+    quit, read_detail, request_refer_image, send_request, send_system_notification,
+    set_auto_launch, set_item,
 };
 use crate::setup::logger::init_logger;
 use crate::setup::system_tray::new_system_tray;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -15,7 +15,7 @@ use tauri::{generate_context, Builder, Context, Manager, WindowEvent};
 use crate::commands::{
     auto_launch_setting, back_preview, copy_image, front_logger, get_app_cache_path,
     get_app_config_path, get_item, get_monitor_info, hide_notification, is_debug, message_beep,
-    quit, read_detail, request_refer_image, send_request, set_auto_launch, set_item,
+    quit, read_detail, request_refer_image, send_request, set_auto_launch, set_item,send_system_notification
 };
 use crate::setup::logger::init_logger;
 use crate::setup::system_tray::new_system_tray;
@@ -68,7 +68,8 @@ fn main() {
                 get_app_cache_path,
                 get_app_config_path,
                 hide_notification,
-                is_debug
+                is_debug,
+                send_system_notification
             ]);
 
         let app = builder

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -16,7 +16,7 @@ use crate::commands::{
     auto_launch_setting, back_preview, copy_image, front_logger, get_app_cache_path,
     get_app_config_path, get_item, get_monitor_info, hide_notification, is_debug, message_beep,
     quit, read_detail, request_refer_image, send_request, send_system_notification,
-    set_auto_launch, set_item,
+    set_auto_launch, set_item,should_silence
 };
 use crate::setup::logger::init_logger;
 use crate::setup::system_tray::new_system_tray;
@@ -70,7 +70,8 @@ fn main() {
                 get_app_config_path,
                 hide_notification,
                 is_debug,
-                send_system_notification
+                send_system_notification,
+                should_silence
             ]);
 
         let app = builder

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -9,7 +9,7 @@
   },
   "package": {
     "productName": "小刻食堂",
-    "version": "1.0.2"
+    "version": "1.0.3"
   },
   "tauri": {
     "systemTray": {

--- a/src/api/operations/notification.ts
+++ b/src/api/operations/notification.ts
@@ -2,6 +2,8 @@ import {appWindow, getAll, WebviewWindow} from "@tauri-apps/api/window";
 import {listen, UnlistenFn, Event} from "@tauri-apps/api/event";
 import {Cookie} from "../resourceFetcher/cookieList";
 import storage from "./localStorage";
+import {invoke} from "@tauri-apps/api";
+
 
 class NotificationOperate {
     async getInfo(callback: (event: string, payload: Cookie) => void,): Promise<UnlistenFn> {
@@ -24,37 +26,56 @@ class NotificationOperate {
     }
 
     async setNotificationMode(modeIdx: number) {
-        console.log("setting Notify mod",modeIdx)
+        console.log("setting Notify mod", modeIdx)
         await storage.setItem("setting.notify", modeIdx);
     }
 
-    async getNotificationMode(): Promise<{ idx: number, value: string ,tip:string}> {
+    async getNotificationMode(): Promise<{ idx: number, value: string, tip: string }> {
         const idx = await storage.getItem<number>("setting.notify") ?? NotifyMode.PopUpAndBeep.idx
-        return allNotifyMode.find((mode)=>mode.idx==idx)!!
+        return allNotifyMode.find((mode) => mode.idx == idx)!!
     }
 
-    async needNotifyPop():Promise<boolean>{
-        const mode =await this.getNotificationMode()
+    async needNotifyPop(): Promise<boolean> {
+        const mode = await this.getNotificationMode()
         return mode.idx == NotifyMode.PopUpOnly.idx || mode.idx == NotifyMode.PopUpAndBeep.idx;
     }
-    async needBeep():Promise<boolean>{
-        const mode = await  this.getNotificationMode()
+
+    async needBeep(): Promise<boolean> {
+        const mode = await this.getNotificationMode()
         return mode.idx == NotifyMode.PopUpAndBeep.idx || mode.idx == NotifyMode.BeepOnly.idx;
     }
+    async needSystemNotify():Promise<boolean>{
+        const mode = await this.getNotificationMode()
+        return mode.idx == NotifyMode.SystemToast.idx
+    }
+
+    async sendSystemNotify(payload: NotifyPayload) {
+        await invoke("send_system_notification", {payload: payload})
+    }
+}
+
+export interface NotifyPayload {
+    title: string,
+    body: string,
+    time:string,
+    has_sound?: boolean,
+    image_url?: string
 }
 
 export const NotifyMode = Object.freeze({
     PopUpOnly: {
-        idx: 0, value: "仅弹窗",tip:"当发现新饼后只会出现右下角弹窗"
+        idx: 0, value: "仅弹窗", tip: "当发现新饼后只会出现右下角弹窗"
     }, BeepOnly: {
-        idx: 1, value: "仅提示音",tip:"当发现新饼后只会发出提示音"
+        idx: 1, value: "仅提示音", tip: "当发现新饼后只会发出提示音"
     }, PopUpAndBeep: {
-        idx: 2, value: "弹窗且提示音",tip:"当发现新饼后不但出现右下角弹窗，同时发出提示音"
+        idx: 2, value: "弹窗且提示音", tip: "当发现新饼后不但出现右下角弹窗，同时发出提示音"
+    }, SystemToast: {
+        idx: 3, value: "使用系统消息", tip: "当发现新饼时发出系统弹窗，Windows可以拉起主窗口"
     }, None: {
-        idx: 3, value: "无",tip:"当发现新饼后无任何行为"
+        idx: -1, value: "无", tip: "当发现新饼后无任何行为"
     },
 })
-export const allNotifyMode = [NotifyMode.PopUpAndBeep, NotifyMode.BeepOnly, NotifyMode.PopUpOnly, NotifyMode.None]
+export const allNotifyMode = [NotifyMode.PopUpAndBeep, NotifyMode.BeepOnly, NotifyMode.PopUpOnly,NotifyMode.SystemToast, NotifyMode.None]
 const notification = new NotificationOperate();
 
 export default notification;

--- a/src/api/operations/notification.ts
+++ b/src/api/operations/notification.ts
@@ -32,7 +32,8 @@ class NotificationOperate {
 
     async getNotificationMode(): Promise<{ idx: number, value: string, tip: string }> {
         const idx = await storage.getItem<number>("setting.notify") ?? NotifyMode.PopUpAndBeep.idx
-        return allNotifyMode.find((mode) => mode.idx == idx)!!
+        const mode = allNotifyMode.find((mode) => mode.idx == idx);
+        return mode?mode:NotifyMode.None
     }
 
     async needNotifyPop(): Promise<boolean> {
@@ -70,9 +71,9 @@ export const NotifyMode = Object.freeze({
     }, PopUpAndBeep: {
         idx: 2, value: "弹窗且提示音", tip: "当发现新饼后不但出现右下角弹窗，同时发出提示音"
     }, SystemToast: {
-        idx: 3, value: "使用系统消息", tip: "当发现新饼时发出系统弹窗，Windows可以拉起主窗口"
+        idx: 4, value: "使用系统消息", tip: "当发现新饼时发出系统弹窗，Windows可以拉起主窗口"
     }, None: {
-        idx: -1, value: "无", tip: "当发现新饼后无任何行为"
+        idx: 3, value: "无",tip:"当发现新饼后无任何行为"
     },
 })
 export const allNotifyMode = [NotifyMode.PopUpAndBeep, NotifyMode.BeepOnly, NotifyMode.PopUpOnly,NotifyMode.SystemToast, NotifyMode.None]

--- a/src/api/operations/operate.ts
+++ b/src/api/operations/operate.ts
@@ -28,8 +28,17 @@ class Operate {
             console.log(await window.outerPosition());
             console.log("send cookie ", cookie)
             await window.emit("new_cookie_info", cookie);
-        }else if (await notification.needBeep()){
-          await this.messageBeep()
+        } else if (await notification.needBeep()) {
+            await this.messageBeep()
+        } else if (await notification.needSystemNotify()) {
+            await notification.sendSystemNotify({
+                body: cookie.default_cookie.text,
+                has_sound: true,
+                time:new Date(cookie.timestamp.platform!).toLocaleString(),
+                image_url: cookie.default_cookie.images ? cookie.default_cookie.images[0].origin_url: undefined ,
+                title: `小刻在${cookie.datasource}蹲到饼了`
+
+            })
         }
     }
 

--- a/src/api/operations/operate.ts
+++ b/src/api/operations/operate.ts
@@ -11,6 +11,10 @@ import notification from "./notification";
 class Operate {
     async openNotificationWindow(cookie: Cookie) {
         console.log(`send Notification`);
+        if (await invoke("should_silence")){
+            return
+        }
+
         if (await notification.needNotifyPop()) {
 
             let monitorInfo = await invoke<{

--- a/src/api/operations/operate.ts
+++ b/src/api/operations/operate.ts
@@ -12,6 +12,7 @@ class Operate {
     async openNotificationWindow(cookie: Cookie) {
         console.log(`send Notification`);
         if (await invoke("should_silence")){
+            console.log("Detect FullScreen, cancel notify")
             return
         }
 

--- a/src/components/SettingPage.vue
+++ b/src/components/SettingPage.vue
@@ -97,7 +97,7 @@ const sen_d = () => {
     datasource: 'kkwd',
     default_cookie: {
       images: [{compress_url: null, origin_url: 'https://i0.hdslb.com/bfs/new_dyn/2956e376fb056cf79cc95bcf585dbbc0161775300.jpg'}],
-      text: '欸嘿嘿，桃金娘的脚小小的~香香的~.'
+      text: '欸嘿嘿，桃金娘的脚小小的~香香的~.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
     },
     icon: '/assets/icon/anime.png',
     source: {data: '123', type: 'nn'},

--- a/src/components/SettingPage.vue
+++ b/src/components/SettingPage.vue
@@ -93,6 +93,9 @@ const isDebug = computed(() => {
 
 // test send notification
 const sen_d = () => {
+  setTimeout(
+      ()=>{
+
   operate.openNotificationWindow({
     datasource: 'kkwd',
     default_cookie: {
@@ -103,6 +106,7 @@ const sen_d = () => {
     source: {data: '123', type: 'nn'},
     timestamp: {fetcher: 114514, platform: 114514, platform_precision: 'minute'}
   })
+      },5000)
 }
 
 const showDownload = computed(() => props.versionState === VersionStateType.UpdateAvailable)

--- a/src/view/Notification.vue
+++ b/src/view/Notification.vue
@@ -10,7 +10,7 @@
       >
         <v-toolbar color="rgba(0, 0, 0, 0)" theme="dark">
           <template #append>
-            <v-btn icon="fas fa-circle-xmark" size="small"></v-btn>
+            <v-btn icon="fas fa-circle-xmark" size="xs" @click="appWindow.hide()"   class="elevation-4" color="amber-accent-4"></v-btn>
           </template>
         </v-toolbar>
       </v-img>
@@ -77,6 +77,9 @@ onMounted(() => {
     console.log("get Info: ", data)
     updatePageData(data);
     await appWindow.show()
+    setTimeout(()=>{
+      appWindow.hide()
+    },10000);
     if (await notification.needBeep()) {
 
       await operate.messageBeep()

--- a/src/view/home/TimeLine.vue
+++ b/src/view/home/TimeLine.vue
@@ -148,6 +148,7 @@ import { getCookieList } from "@/api/resourceFetcher/cookieList";
 import Common from "../../components/Card/Common.vue";
 import { previewUrl } from "@/utils/previewUtil";
 import logger from "@/api/operations/logger";
+import { type, OsType } from "@tauri-apps/api/os"
 
 const router = useRouter();
 
@@ -253,6 +254,7 @@ function searchTimeline() {
 
 // 卡片操作
 const card = reactive({
+  osType: "",
   isCopyImage: false, // 当前是否在截图
   copyImageId: null,
   openUrlInThis(data: { url: string; icon: string; source: string }) {
@@ -266,9 +268,15 @@ const card = reactive({
     card.copyImageId = id;
     card.isCopyImage = true;
     setTimeout(() => {
-      nextTick(() => {
+      nextTick(async () => {
+        // 包的问题，非windows多截图一次，详见：https://github.com/bubkoo/html-to-image/issues/147
+        if (card.osType !=  "Windows_NT") {
+          await htmlToImage
+            .toJpeg(document.getElementById(id), { quality: 0.95, pixelRatio: 3 })
+        }
+
         htmlToImage
-          .toJpeg(document.getElementById(id), { quality: 0.95 })
+          .toJpeg(document.getElementById(id), { quality: 0.95, pixelRatio: 3 })
           .then(function (dataUrl) {
             card.isCopyImage = false;
             operate.copy({ type: "img", data: dataUrl });
@@ -389,6 +397,9 @@ onMounted(() => {
     true,
   );
   searchTimeline();
+  type().then((osType: OsType) => {
+    card.osType = osType;
+  })
 });
 </script>
 

--- a/src/view/home/TimeLine.vue
+++ b/src/view/home/TimeLine.vue
@@ -136,7 +136,7 @@
 </template>
 
 <script lang="ts" name="timeLine" setup>
-import { nextTick, onMounted, reactive } from "vue";
+import { nextTick, onMounted, reactive, getCurrentInstance } from "vue";
 import { useRouter } from "vue-router";
 import * as htmlToImage from "html-to-image";
 import newestTimeline, { Timeline } from "../../api/operations/newestTimeline";
@@ -149,6 +149,8 @@ import Common from "../../components/Card/Common.vue";
 import { previewUrl } from "@/utils/previewUtil";
 import logger from "@/api/operations/logger";
 import { type, OsType } from "@tauri-apps/api/os"
+
+const instance = getCurrentInstance();
 
 const router = useRouter();
 
@@ -193,6 +195,7 @@ async function getData() {
       timeline.refreshUpdateCookieId = arg.update_cookie_id;
       timeline.refreshNextPageId = arg.next_page_id ?? null;
     }
+    instance.proxy.$forceUpdate();
   });
 }
 
@@ -210,6 +213,7 @@ function refreshTimeline() {
   timeline.refreshUpdateCookieId = null;
   timeline.nextPageId = timeline.refreshNextPageId;
   timeline.refreshNextPageId = null;
+  instance.proxy.$forceUpdate();
   document.querySelector(".time-line").scrollTop = 0;
 }
 
@@ -227,6 +231,7 @@ function searchTimeline() {
         timeline.timelineData = null;
         timeline.nextPageId = null;
         timeline.searchStatus = true;
+        instance.proxy.$forceUpdate();
         document.querySelector(".time-line").scrollTop = 0;
       }
       getCookieSearchList({
@@ -237,6 +242,7 @@ function searchTimeline() {
           let respData = data.data.data;
           timeline.timelineData = respData.cookies;
           timeline.nextPageId = respData.next_page_id ?? null;
+          instance.proxy.$forceUpdate();
         }
       });
     } else {
@@ -246,6 +252,7 @@ function searchTimeline() {
         timeline.searchStatus = false;
         timeline.timelineData = timeline.tempTimelineData?.slice(0) ?? null;
         timeline.nextPageId = timeline.tempNextPageId;
+        instance.proxy.$forceUpdate();
         document.querySelector(".time-line").scrollTop = 0;
       }
     }


### PR DESCRIPTION
## 新Feature
- 新饼推送弹窗将会在10s后自动关闭 #51 
- 新饼推送弹窗添加关闭按键 #51 
- 可以选择使用系统Toast消息进行新饼推送 #55 
  > 注意：只有Windows 下系统消息新饼推送可以携带图片并拉起主窗口
- 当用户使用全屏应用时，不进行推送 #61 
  > 注意：该功能不可关闭，且只在Windows下生效

## 修复Bug
- 修复 Linux , MacOS 下卡片分享的生成图片异常 
- 尝试修复Timeline 特殊清空下排序异常 

## Note
由于添加了新的新饼推送选项，如果从当前版本降级到1.0.2 或者更早的版本可能会导致新饼推送的配置项消失